### PR TITLE
Split out "request" into "requestKey" and "requestName"

### DIFF
--- a/packages/redux-resource/src/request-statuses-plugin/delete.js
+++ b/packages/redux-resource/src/request-statuses-plugin/delete.js
@@ -10,9 +10,15 @@ const delIdle = reducerGenerator('delete', requestStatuses.IDLE);
 function delSucceed(state, action, { initialResourceMeta }) {
   const resources = action.resources;
 
-  let request;
+  let requestKey, requestName;
   if (action.request && typeof action.request === 'string') {
-    request = action.request;
+    requestKey = requestName = action.request;
+  }
+  if (action.requestKey && typeof action.requestKey === 'string') {
+    requestKey = action.requestKey;
+  }
+  if (action.requestName && typeof action.requestName === 'string') {
+    requestName = action.requestName;
   }
 
   if (process.env.NODE_ENV !== 'production') {
@@ -85,8 +91,8 @@ function delSucceed(state, action, { initialResourceMeta }) {
 
   const hasIds = idList && idList.length;
 
-  // If we have no IDs nor request, then there is nothing to update
-  if (!hasIds && !request) {
+  // If we have no IDs nor requestKey, then there is nothing to update
+  if (!hasIds && !requestKey) {
     return state;
   }
 
@@ -97,15 +103,21 @@ function delSucceed(state, action, { initialResourceMeta }) {
   const requests = state.requests;
   const lists = state.lists;
 
-  if (request) {
-    const existingRequest = requests[request] || {};
+  if (requestKey) {
+    const existingRequest = requests[requestKey] || {};
+    const newRequest = {
+      ...existingRequest,
+      requestKey,
+      status: requestStatuses.SUCCEEDED,
+      ids: idList || [],
+    };
+
+    if (requestName) {
+      newRequest.requestName = requestName;
+    }
     newRequests = {
       ...requests,
-      [request]: {
-        ...existingRequest,
-        status: requestStatuses.SUCCEEDED,
-        ids: idList || [],
-      },
+      [requestKey]: newRequest,
     };
   } else {
     newRequests = requests;

--- a/packages/redux-resource/src/utils/cru-reducer-helper.js
+++ b/packages/redux-resource/src/utils/cru-reducer-helper.js
@@ -10,9 +10,15 @@ export default function(state, action, { initialResourceMeta }, updatedMeta) {
   const resourcesIsUndefined = typeof resources === 'undefined';
   const hasResources = resources && resources.length;
 
-  let request;
+  let requestKey, requestName;
   if (action.request && typeof action.request === 'string') {
-    request = action.request;
+    requestKey = requestName = action.request;
+  }
+  if (action.requestKey && typeof action.requestKey === 'string') {
+    requestKey = action.requestKey;
+  }
+  if (action.requestName && typeof action.requestName === 'string') {
+    requestName = action.requestName;
   }
 
   let list;
@@ -42,8 +48,8 @@ export default function(state, action, { initialResourceMeta }, updatedMeta) {
     }
   }
 
-  // Without resources, a list, or a request name, there is nothing to update
-  if (!hasResources && !request && !list) {
+  // Without resources, a list, or a request key, there is nothing to update
+  if (!hasResources && !requestKey && !list) {
     return state;
   }
 
@@ -57,16 +63,21 @@ export default function(state, action, { initialResourceMeta }, updatedMeta) {
     meta: state.meta,
     newMeta: updatedMeta,
     mergeMeta: action.mergeMeta,
-    initialResourceMeta
+    initialResourceMeta,
   });
 
   let newRequests;
-  if (request) {
-    const existingRequest = state.requests[request] || {};
+  if (requestKey) {
+    const existingRequest = state.requests[requestKey] || {};
     const newRequest = {
       ...existingRequest,
-      status: requestStatuses.SUCCEEDED
+      requestKey,
+      status: requestStatuses.SUCCEEDED,
     };
+
+    if (requestName) {
+      newRequest.requestName = requestName;
+    }
 
     let newRequestIds;
     if (hasResources) {
@@ -78,7 +89,7 @@ export default function(state, action, { initialResourceMeta }, updatedMeta) {
 
     newRequests = {
       ...state.requests,
-      [request]: newRequest
+      [requestKey]: newRequest,
     };
   } else {
     newRequests = state.requests;
@@ -110,7 +121,7 @@ export default function(state, action, { initialResourceMeta }, updatedMeta) {
 
     newLists = {
       ...state.lists,
-      [list]: newList || currentList
+      [list]: newList || currentList,
     };
   } else {
     newLists = state.lists;
@@ -121,6 +132,6 @@ export default function(state, action, { initialResourceMeta }, updatedMeta) {
     resources: newResources,
     meta: newMeta,
     requests: newRequests,
-    lists: newLists
+    lists: newLists,
   };
 }

--- a/packages/redux-resource/src/utils/reducer-generator.js
+++ b/packages/redux-resource/src/utils/reducer-generator.js
@@ -18,9 +18,15 @@ export default function(crudAction, requestStatus) {
     const resources = action.resources;
     const mergeMeta = action.mergeMeta;
 
-    let request;
+    let requestKey, requestName;
     if (action.request && typeof action.request === 'string') {
-      request = action.request;
+      requestKey = requestName = action.request;
+    }
+    if (action.requestKey && typeof action.requestKey === 'string') {
+      requestKey = action.requestKey;
+    }
+    if (action.requestName && typeof action.requestName === 'string') {
+      requestName = action.requestName;
     }
 
     let idList;
@@ -39,11 +45,11 @@ export default function(crudAction, requestStatus) {
     const statusAttribute = `${crudAction}Status`;
     let newRequests, newMeta, newLists;
 
-    if (!request && !idList.length) {
+    if (!requestKey && !idList.length) {
       if (process.env.NODE_ENV !== 'production') {
         warning(
           `A Redux Resource action of type ${action.type} was dispatched ` +
-            `without a "request" or "resources" array. Without one of these ` +
+            `without a "requestKey" or "resources" array. Without one of these ` +
             `values, Redux Resource cannot track the request status for this` +
             `CRUD operation. You should check your Action Creators. Read more about` +
             `request tracking at: https://redux-resource.js.org/docs/guides/tracking-requests.html`
@@ -53,15 +59,22 @@ export default function(crudAction, requestStatus) {
       return state;
     }
 
-    if (request) {
-      const existingRequest = state.requests[request] || {};
+    if (requestKey) {
+      const existingRequest = state.requests[requestKey] || {};
+
+      const newRequest = {
+        ...existingRequest,
+        requestKey,
+        status: requestStatus,
+      };
+
+      if (requestName) {
+        newRequest.requestName = requestName;
+      }
 
       newRequests = {
         ...state.requests,
-        [request]: {
-          ...existingRequest,
-          status: requestStatus
-        }
+        [requestKey]: newRequest,
       };
     } else {
       newRequests = state.requests;
@@ -78,8 +91,8 @@ export default function(crudAction, requestStatus) {
         mergeMeta,
         initialResourceMeta: {
           ...initialResourceMetaState,
-          ...initialResourceMeta
-        }
+          ...initialResourceMeta,
+        },
       });
     } else {
       newMeta = state.meta;
@@ -89,7 +102,7 @@ export default function(crudAction, requestStatus) {
       ...state,
       requests: newRequests,
       lists: newLists,
-      meta: newMeta
+      meta: newMeta,
     };
   };
 }

--- a/packages/redux-resource/test/unit/reducers/delete.js
+++ b/packages/redux-resource/test/unit/reducers/delete.js
@@ -427,6 +427,252 @@ describe('reducers: delete', function() {
         lists: {},
         requests: {
           italiano: {
+            requestKey: 'italiano',
+            requestName: 'italiano',
+            status: requestStatuses.SUCCEEDED,
+            ids: [3, 4],
+            hangry: false,
+          },
+          oink: {
+            ids: [10, 3],
+            hungry: true,
+          },
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.IDLE,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.SUCCEEDED,
+          },
+          4: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.IDLE,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.SUCCEEDED,
+          },
+        },
+      });
+      expect(console.error.callCount).to.equal(0);
+    });
+
+    it('returns the right state with a request key and name, with IDs', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: { id: 1 },
+            3: { id: 3 },
+            4: { id: 4 },
+          },
+          lists: {},
+          requests: {
+            oink: {
+              hungry: true,
+              ids: [10, 3],
+            },
+            abc12345: {
+              status: requestStatuses.PENDING,
+              ids: [1, 3, 4],
+              hangry: false,
+            },
+          },
+          meta: {
+            1: {
+              name: 'what',
+            },
+            3: {
+              deleteStatus: 'sandwiches',
+            },
+          },
+        },
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'DELETE_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        requestKey: 'abc12345',
+        requestName: 'deleteStuff',
+        resources: [3, { id: 4 }],
+      });
+
+      expect(reduced).to.deep.equal({
+        resourceType: 'hellos',
+        resources: {
+          1: { id: 1 },
+          3: null,
+          4: null,
+        },
+        lists: {},
+        requests: {
+          abc12345: {
+            requestKey: 'abc12345',
+            requestName: 'deleteStuff',
+            status: requestStatuses.SUCCEEDED,
+            ids: [3, 4],
+            hangry: false,
+          },
+          oink: {
+            ids: [10, 3],
+            hungry: true,
+          },
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.IDLE,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.SUCCEEDED,
+          },
+          4: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.IDLE,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.SUCCEEDED,
+          },
+        },
+      });
+      expect(console.error.callCount).to.equal(0);
+    });
+
+    it('returns the right state with a request key and request name, with IDs', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: { id: 1 },
+            3: { id: 3 },
+            4: { id: 4 },
+          },
+          lists: {},
+          requests: {
+            oink: {
+              hungry: true,
+              ids: [10, 3],
+            },
+            abc12345: {
+              status: requestStatuses.PENDING,
+              ids: [1, 3, 4],
+              hangry: false,
+            },
+          },
+          meta: {
+            1: {
+              name: 'what',
+            },
+            3: {
+              deleteStatus: 'sandwiches',
+            },
+          },
+        },
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'DELETE_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        requestKey: 'abc12345',
+        requestName: 'deleteStuff',
+        resources: [3, { id: 4 }],
+      });
+
+      expect(reduced).to.deep.equal({
+        resourceType: 'hellos',
+        resources: {
+          1: { id: 1 },
+          3: null,
+          4: null,
+        },
+        lists: {},
+        requests: {
+          abc12345: {
+            requestKey: 'abc12345',
+            requestName: 'deleteStuff',
+            status: requestStatuses.SUCCEEDED,
+            ids: [3, 4],
+            hangry: false,
+          },
+          oink: {
+            ids: [10, 3],
+            hungry: true,
+          },
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.IDLE,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.SUCCEEDED,
+          },
+          4: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.IDLE,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.SUCCEEDED,
+          },
+        },
+      });
+      expect(console.error.callCount).to.equal(0);
+    });
+
+    it('returns the right state with a request key and no request name, with IDs', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: { id: 1 },
+            3: { id: 3 },
+            4: { id: 4 },
+          },
+          lists: {},
+          requests: {
+            oink: {
+              hungry: true,
+              ids: [10, 3],
+            },
+            abc12345: {
+              status: requestStatuses.PENDING,
+              ids: [1, 3, 4],
+              hangry: false,
+            },
+          },
+          meta: {
+            1: {
+              name: 'what',
+            },
+            3: {
+              deleteStatus: 'sandwiches',
+            },
+          },
+        },
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'DELETE_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        requestKey: 'abc12345',
+        resources: [3, { id: 4 }],
+      });
+
+      expect(reduced).to.deep.equal({
+        resourceType: 'hellos',
+        resources: {
+          1: { id: 1 },
+          3: null,
+          4: null,
+        },
+        lists: {},
+        requests: {
+          abc12345: {
+            requestKey: 'abc12345',
             status: requestStatuses.SUCCEEDED,
             ids: [3, 4],
             hangry: false,
@@ -652,6 +898,8 @@ describe('reducers: delete', function() {
         },
         requests: {
           italiano: {
+            requestKey: 'italiano',
+            requestName: 'italiano',
             status: requestStatuses.SUCCEEDED,
             ids: [],
             hangry: false,

--- a/packages/redux-resource/test/unit/reducers/read.js
+++ b/packages/redux-resource/test/unit/reducers/read.js
@@ -689,6 +689,182 @@ describe('reducers: read:', function() {
             status: requestStatuses.FAILED,
           },
           pasta: {
+            requestKey: 'pasta',
+            requestName: 'pasta',
+            ids: [4, 5],
+            status: requestStatuses.SUCCEEDED,
+          },
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+          4: {
+            selected: true,
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.SUCCEEDED,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.IDLE,
+          },
+          5: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.SUCCEEDED,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.IDLE,
+          },
+        },
+      });
+      expect(console.error.callCount).to.equal(0);
+    });
+
+    it('returns state with resource object and request key+name, ensuring no request ID dupes', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: { id: 1 },
+            3: { id: 3 },
+            4: { id: 4, lastName: 'camomile' },
+          },
+          lists: {},
+          requests: {
+            sandwiches: {
+              ids: [1, 3],
+              status: requestStatuses.FAILED,
+            },
+            abc12345: {
+              ids: [4],
+              status: requestStatuses.PENDING,
+            },
+          },
+          meta: {
+            1: {
+              name: 'what',
+            },
+            3: {
+              deleteStatus: 'sandwiches',
+            },
+            4: {
+              selected: true,
+            },
+          },
+        },
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'READ_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        requestKey: 'abc12345',
+        requestName: 'readStuff',
+        resources: [{ id: 4, name: 'sandwiches' }, 5],
+      });
+
+      expect(reduced).to.deep.equal({
+        resourceType: 'hellos',
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4, name: 'sandwiches', lastName: 'camomile' },
+          5: { id: 5 },
+        },
+        lists: {},
+        requests: {
+          sandwiches: {
+            ids: [1, 3],
+            status: requestStatuses.FAILED,
+          },
+          abc12345: {
+            requestKey: 'abc12345',
+            requestName: 'readStuff',
+            ids: [4, 5],
+            status: requestStatuses.SUCCEEDED,
+          },
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+          4: {
+            selected: true,
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.SUCCEEDED,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.IDLE,
+          },
+          5: {
+            createStatus: requestStatuses.IDLE,
+            readStatus: requestStatuses.SUCCEEDED,
+            updateStatus: requestStatuses.IDLE,
+            deleteStatus: requestStatuses.IDLE,
+          },
+        },
+      });
+      expect(console.error.callCount).to.equal(0);
+    });
+
+    it('returns state with resource object and request key + no name, ensuring no request ID dupes', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: { id: 1 },
+            3: { id: 3 },
+            4: { id: 4, lastName: 'camomile' },
+          },
+          lists: {},
+          requests: {
+            sandwiches: {
+              ids: [1, 3],
+              status: requestStatuses.FAILED,
+            },
+            abc12345: {
+              ids: [4],
+              status: requestStatuses.PENDING,
+            },
+          },
+          meta: {
+            1: {
+              name: 'what',
+            },
+            3: {
+              deleteStatus: 'sandwiches',
+            },
+            4: {
+              selected: true,
+            },
+          },
+        },
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'READ_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        requestKey: 'abc12345',
+        resources: [{ id: 4, name: 'sandwiches' }, 5],
+      });
+
+      expect(reduced).to.deep.equal({
+        resourceType: 'hellos',
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4, name: 'sandwiches', lastName: 'camomile' },
+          5: { id: 5 },
+        },
+        lists: {},
+        requests: {
+          sandwiches: {
+            ids: [1, 3],
+            status: requestStatuses.FAILED,
+          },
+          abc12345: {
+            requestKey: 'abc12345',
             ids: [4, 5],
             status: requestStatuses.SUCCEEDED,
           },
@@ -781,6 +957,8 @@ describe('reducers: read:', function() {
             status: requestStatuses.FAILED,
           },
           pasta: {
+            requestKey: 'pasta',
+            requestName: 'pasta',
             ids: [4, 5],
             status: requestStatuses.SUCCEEDED,
           },
@@ -864,6 +1042,8 @@ describe('reducers: read:', function() {
             status: requestStatuses.FAILED,
           },
           pasta: {
+            requestKey: 'pasta',
+            requestName: 'pasta',
             ids: [4, 5],
             status: requestStatuses.SUCCEEDED,
           },
@@ -1146,6 +1326,8 @@ describe('reducers: read:', function() {
             status: requestStatuses.FAILED,
           },
           pasta: {
+            requestKey: 'pasta',
+            requestName: 'pasta',
             ids: [],
             status: requestStatuses.SUCCEEDED,
           },

--- a/packages/redux-resource/test/unit/utils/reducer-generator.js
+++ b/packages/redux-resource/test/unit/utils/reducer-generator.js
@@ -36,7 +36,7 @@ describe('reducerGenerator:', function() {
     expect(console.error.callCount).to.equal(1);
   });
 
-  it('passing mixed resources array and no request name', () => {
+  it('passing mixed resources array and no request key', () => {
     const state = {
       meta: {
         1: {
@@ -123,7 +123,7 @@ describe('reducerGenerator:', function() {
     });
   });
 
-  it('passing resources and no request name', () => {
+  it('passing resources and no request key', () => {
     const state = {
       meta: {
         1: {
@@ -198,7 +198,7 @@ describe('reducerGenerator:', function() {
     });
   });
 
-  it('passing no IDs, but passing a request name', () => {
+  it('passing no IDs, but passing a request key', () => {
     const state = {
       meta: {
         1: {
@@ -245,6 +245,8 @@ describe('reducerGenerator:', function() {
       },
       requests: {
         italiano: {
+          requestKey: 'italiano',
+          requestName: 'italiano',
           sandwiches: true,
           status: requestStatuses.FAILED,
         },
@@ -255,7 +257,7 @@ describe('reducerGenerator:', function() {
     });
   });
 
-  it('passing IDs and passing a request name', () => {
+  it('passing IDs and passing a request key', () => {
     const state = {
       meta: {
         1: {
@@ -321,6 +323,8 @@ describe('reducerGenerator:', function() {
       },
       requests: {
         italiano: {
+          requestKey: 'italiano',
+          requestName: 'italiano',
           sandwiches: true,
           status: requestStatuses.FAILED,
         },
@@ -331,7 +335,166 @@ describe('reducerGenerator:', function() {
     });
   });
 
-  it('passing IDs and passing a request name with `mergeMeta: false`', () => {
+  it('passing IDs and passing a request key, but no request name', () => {
+    const state = {
+      meta: {
+        1: {
+          pastaStatus: requestStatuses.PENDING,
+          hangry: true,
+        },
+        2: {
+          pastaStatus: requestStatuses.FAILED,
+          sandwichStatus: requestStatuses.PENDING,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+      },
+      requests: {
+        italiano: {
+          sandwiches: true,
+          status: requestStatuses.PENDING,
+        },
+        meep: {
+          hungry: true,
+        },
+      },
+    };
+
+    const reducer = reducerGenerator('pasta', requestStatuses.FAILED);
+    const result = reducer(state, {
+      resources: [1, 5, 6],
+      requestKey: 'italiano',
+    });
+
+    expect(result).to.deep.equal({
+      meta: {
+        1: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.IDLE,
+          pastaStatus: requestStatuses.FAILED,
+          hangry: true,
+        },
+        2: {
+          pastaStatus: requestStatuses.FAILED,
+          sandwichStatus: requestStatuses.PENDING,
+        },
+        5: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.IDLE,
+          pastaStatus: requestStatuses.FAILED,
+        },
+        6: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.IDLE,
+          pastaStatus: requestStatuses.FAILED,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+      },
+      requests: {
+        italiano: {
+          requestKey: 'italiano',
+          sandwiches: true,
+          status: requestStatuses.FAILED,
+        },
+        meep: {
+          hungry: true,
+        },
+      },
+    });
+  });
+
+  it('passing IDs and passing a request key and request name', () => {
+    const state = {
+      meta: {
+        1: {
+          pastaStatus: requestStatuses.PENDING,
+          hangry: true,
+        },
+        2: {
+          pastaStatus: requestStatuses.FAILED,
+          sandwichStatus: requestStatuses.PENDING,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+      },
+      requests: {
+        italiano: {
+          sandwiches: true,
+          status: requestStatuses.PENDING,
+        },
+        meep: {
+          hungry: true,
+        },
+      },
+    };
+
+    const reducer = reducerGenerator('pasta', requestStatuses.FAILED);
+    const result = reducer(state, {
+      resources: [1, 5, 6],
+      requestKey: 'abc12345',
+      requestName: 'someRequest',
+    });
+
+    expect(result).to.deep.equal({
+      meta: {
+        1: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.IDLE,
+          pastaStatus: requestStatuses.FAILED,
+          hangry: true,
+        },
+        2: {
+          pastaStatus: requestStatuses.FAILED,
+          sandwichStatus: requestStatuses.PENDING,
+        },
+        5: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.IDLE,
+          pastaStatus: requestStatuses.FAILED,
+        },
+        6: {
+          createStatus: requestStatuses.IDLE,
+          readStatus: requestStatuses.IDLE,
+          updateStatus: requestStatuses.IDLE,
+          deleteStatus: requestStatuses.IDLE,
+          pastaStatus: requestStatuses.FAILED,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+      },
+      requests: {
+        italiano: {
+          sandwiches: true,
+          status: requestStatuses.PENDING,
+        },
+        abc12345: {
+          requestKey: 'abc12345',
+          requestName: 'someRequest',
+          status: requestStatuses.FAILED,
+        },
+        meep: {
+          hungry: true,
+        },
+      },
+    });
+  });
+
+  it('passing IDs and passing a request key with `mergeMeta: false`', () => {
     const state = {
       meta: {
         1: {
@@ -397,6 +560,8 @@ describe('reducerGenerator:', function() {
       },
       requests: {
         italiano: {
+          requestKey: 'italiano',
+          requestName: 'italiano',
           sandwiches: true,
           status: requestStatuses.FAILED,
         },


### PR DESCRIPTION
The option `request` serves two purposes right now:

1. acting as a "key" that can be used for caching
2. a human-readable name of the request that is useful for debugging

This PR splits that out into two separate properties, `requestKey` and `requestName`, so that it is more clear what is going on.

`request` continues to work as a shorthand for both of these values.
