### PR TITLE
Successful requests always set IDs on the request

### DIFF
--- a/packages/redux-resource/src/utils/cru-reducer-helper.js
+++ b/packages/redux-resource/src/utils/cru-reducer-helper.js
@@ -94,9 +94,7 @@ export default function(state, action, { initialResourceMeta }, updatedMeta) {
       });
     }
 
-    if (newRequestIds) {
-      newRequest.ids = newRequestIds;
-    }
+    newRequest.ids = newRequestIds || [];
 
     newRequests = {
       ...state.requests,

--- a/packages/redux-resource/test/unit/reducers/read.js
+++ b/packages/redux-resource/test/unit/reducers/read.js
@@ -1356,7 +1356,7 @@ describe('reducers: read:', function() {
             requestKey: 'pasta',
             requestName: 'pasta',
             resourceType: 'hellos',
-            ids: [1],
+            ids: [],
             status: requestStatuses.SUCCEEDED,
           },
         },
@@ -1374,6 +1374,84 @@ describe('reducers: read:', function() {
       });
 
       expect(console.error.callCount).to.equal(1);
+    });
+
+    it('returns state with an empty resource array, with a request name', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: { id: 1 },
+            3: { id: 3 },
+            4: { id: 4, lastName: 'camomile' },
+          },
+          lists: {},
+          requests: {
+            sandwiches: {
+              ids: [1, 3],
+              status: requestStatuses.FAILED,
+            },
+            pasta: {
+              ids: [1],
+              status: requestStatuses.PENDING,
+            },
+          },
+          meta: {
+            1: {
+              name: 'what',
+            },
+            3: {
+              deleteStatus: 'sandwiches',
+            },
+            4: {
+              selected: true,
+            },
+          },
+        },
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'READ_RESOURCES_SUCCEEDED',
+        resourceType: 'hellos',
+        request: 'pasta',
+        resources: []
+      });
+
+      expect(reduced).to.deep.equal({
+        resourceType: 'hellos',
+        resources: {
+          1: { id: 1 },
+          3: { id: 3 },
+          4: { id: 4, lastName: 'camomile' },
+        },
+        lists: {},
+        requests: {
+          sandwiches: {
+            ids: [1, 3],
+            status: requestStatuses.FAILED,
+          },
+          pasta: {
+            requestKey: 'pasta',
+            requestName: 'pasta',
+            resourceType: 'hellos',
+            ids: [],
+            status: requestStatuses.SUCCEEDED,
+          },
+        },
+        meta: {
+          1: {
+            name: 'what',
+          },
+          3: {
+            deleteStatus: 'sandwiches',
+          },
+          4: {
+            selected: true,
+          },
+        },
+      });
+
+      expect(console.error.callCount).to.equal(0);
     });
   });
 


### PR DESCRIPTION
Reverts #372 

I do not remember why I went with 372, but it is important for an empty success to wipe the resources array. Imagine this situation:

- user requests their favorite books
- 10 books are returned
- later, they request their favorite books again
- their favorites have been deleted, so 0 results are returned
- redux-resource does not update the resources 🤷‍♂️ 

This ensures that the last step actually updates the resource list 