### PR TITLE
Strict mode does not allow function declarations in a lexically nested statement

### DIFF
--- a/packages/redux-resource/src/action-types/index.js
+++ b/packages/redux-resource/src/action-types/index.js
@@ -9,7 +9,7 @@ const allTypes = {
 
 if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line
-  function warn(propName) {
+  const warn = function(propName) {
     const newPropName = propName
       .split('_')
       .slice(0, 2)


### PR DESCRIPTION
Strict mode does not allow function declarations in a lexically nested statement.
Got this error on react-native, typescript and android.

![2018-06-27 18 14 41](https://user-images.githubusercontent.com/459452/41985152-31c07ae4-7a3b-11e8-9b03-a2cbe3233409.png)
