### PR TITLE
Remove an invalid warning when deleting resources in some cases

### DIFF
--- a/packages/redux-resource/src/update-resources-plugin/index.js
+++ b/packages/redux-resource/src/update-resources-plugin/index.js
@@ -90,10 +90,10 @@ export default (resourceType, { initialResourceMeta }) => (state, action) => {
     };
   } else {
     if (process.env.NODE_ENV !== 'production') {
-      if (!naiveNewResources && !naiveNewMeta) {
+      if (!action.resources && !action.meta) {
         warning(
-          `You dispatched a DELETE_RESOURCES action without any resources or meta, ` +
-            `so the store will not be updated. ` +
+          `You dispatched a DELETE_RESOURCES action without any resources ` +
+            `or meta, so the store will not be updated. ` +
             `For more information, refer to the documentation on this action at: ` +
             `https://redux-resource.js.org/docs/resources/modifying-resources.html`,
           'DELETE_RESOURCES_NO_OP'

--- a/packages/redux-resource/test/unit/reducers/delete-resources.js
+++ b/packages/redux-resource/test/unit/reducers/delete-resources.js
@@ -422,4 +422,52 @@ describe('reducers: DELETE_RESOURCES', function() {
     });
     expect(console.error.callCount).to.equal(0);
   });
+
+  it('does not warn when another resource type is attempted to be deleted', () => {
+    stub(console, 'error');
+    const initialState = {
+      resources: {
+        1: { id: 1 },
+        3: { id: 3 },
+        4: { id: 4 },
+      },
+      requests: {
+        pasta: {
+          hungry: true,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+      },
+      meta: {
+        1: {
+          name: 'what',
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+      },
+    };
+
+    const reducer = resourceReducer('hellos', { initialState });
+
+    const reduced = reducer(undefined, {
+      type: 'DELETE_RESOURCES',
+      resources: {
+        sandwiches: [
+          1,
+          {
+            id: 13,
+            name: 'Test3',
+          },
+        ],
+      },
+    });
+
+    expect(reduced).to.deep.equal({
+      ...initialState,
+      resourceType: 'hellos',
+    });
+    expect(console.error.callCount).to.equal(0);
+  });
 });

--- a/packages/redux-resource/test/unit/reducers/update-resources.js
+++ b/packages/redux-resource/test/unit/reducers/update-resources.js
@@ -648,4 +648,50 @@ describe('reducers: UPDATE_RESOURCES', function() {
       expect(console.error.callCount).to.equal(0);
     });
   });
+
+  it('does not warn when another resource type is attempted to be modified', () => {
+    stub(console, 'error');
+    const initialState = {
+      resources: {
+        1: { id: 1 },
+        3: { id: 3 },
+        4: { id: 4 },
+      },
+      requests: {
+        pasta: {
+          hungry: true,
+        },
+      },
+      lists: {
+        bookmarks: [1, 2, 3],
+      },
+      meta: {
+        1: {
+          name: 'what',
+        },
+        3: {
+          deleteStatus: 'sandwiches',
+        },
+      },
+    };
+
+    const reducer = resourceReducer('hellos', { initialState });
+
+    const reduced = reducer(undefined, {
+      type: 'UPDATE_RESOURCES',
+      meta: {
+        sandwiches: {
+          1: {
+            name: 'Test2',
+          },
+        },
+      },
+    });
+
+    expect(reduced).to.deep.equal({
+      ...initialState,
+      resourceType: 'hellos',
+    });
+    expect(console.error.callCount).to.equal(0);
+  });
 });


### PR DESCRIPTION
Resolves #413 ; supersedes #417 