### PR TITLE
Replaced instanceof with Array.isArray to support iframes

### DIFF
--- a/packages/redux-resource/src/utils/get-status.js
+++ b/packages/redux-resource/src/utils/get-status.js
@@ -82,7 +82,7 @@ function getSingleStatus(state, statusLocation, treatIdleAsPending) {
 // Note that at most _one_ of those properties will be true. It is
 // possible for them to all be false.
 export default function getStatus(state, statusLocations, treatIdleAsPending) {
-  if (!(statusLocations instanceof Array)) {
+  if (!Array.isArray(statusLocations)) {
     const status = getSingleStatus(state, statusLocations, treatIdleAsPending);
 
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/redux-resource/src/utils/set-resource-meta.js
+++ b/packages/redux-resource/src/utils/set-resource-meta.js
@@ -16,7 +16,7 @@ export default function setResourceMeta(options) {
 
   let mergeMetaOption = typeof mergeMeta !== 'undefined' ? mergeMeta : true;
   const resourcesArray =
-    resources instanceof Array ? resources : Object.values(resources);
+    Array.isArray(resources) ? resources : Object.values(resources);
 
   if (!resourcesArray.length) {
     return next;

--- a/packages/redux-resource/src/utils/upsert-resources.js
+++ b/packages/redux-resource/src/utils/upsert-resources.js
@@ -14,7 +14,7 @@ export default function upsertResources(
     typeof mergeResources !== 'undefined' ? mergeResources : true;
   const shallowClone = Object.assign({}, resources);
 
-  if (newResources instanceof Array) {
+  if (Array.isArray(newResources)) {
     newResources.forEach(resource => {
       const resourceIsObject = typeof resource === 'object';
       const id = resourceIsObject ? resource.id : resource;


### PR DESCRIPTION
Hi James!

My team and I faced a weird problem using your library in our project.

Let me briefly explain the scenario:

1. Create a store with redux-resource reducers as usual.
2. Make store accessible globally like `window.store = store;`
3. Add an `<iframe>` to the page. As `src` points on the same domain, so we can access the `store` from the iframe too (`window.parent.store`).
4. Dispatch an action from **iframe**.

The problem is the list of resources is not an instance of Array anymore and your code follows in a wrong way. Please, have a look at the [documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#instanceof_vs_isArray). I reproduced this case for you — https://output.jsbin.com/yotoyexiva Please, check browser’s console.

My suggestion is to replace `instanceof` with `Array.isArray()`, which works perfectly.

Please, let me know you have any questions.