### PR TITLE
Remove deprecated React Component lifecycle methods from docs

### DIFF
--- a/docs/api-reference/get-status.md
+++ b/docs/api-reference/get-status.md
@@ -96,6 +96,6 @@ const bookReadStatus = getStatus(
 
 - The first argument, `state`, doesn't always need to be the state of your
   Redux store. For instance, if you're using this method within your component's
-  lifecycle methods, such as `componentWillReceiveProps`, you may instead pass
+  lifecycle methods, such as `componentDidUpdate`, you may instead pass
   it an object that is a subset of the state. This can be useful when you're
-  comparing a previous status against an upcoming status.
+  comparing a previous status against the current status.

--- a/docs/other-guides/usage-with-react.md
+++ b/docs/other-guides/usage-with-react.md
@@ -46,7 +46,7 @@ Sometimes, you want to know the exact moment that a request succeeds. You can do
 within your components by comparing the previous state with the next state to determine
 when a request changes from one status to another.
 
-We recommend performing this check within `componentWillReceiveProps`. This
+We recommend performing this check within `componentDidUpdate`. This
 might look like:
 
 ```js
@@ -58,8 +58,8 @@ class BooksList extends Component {
   }
 
   // Let's log to the console whenever a search result succeeds
-  componentWillReceiveProps(nextProps) {
-    if (this.props.searchStatus.pending && nextProps.searchStatus.succeeded) {
+  componentDidUpdate(prevProps) {
+    if (this.props.searchStatus.succeeded && prevProps.searchStatus.pending) {
       console.log('The search request just succeeded.');
     }
   }


### PR DESCRIPTION
Resolves #426 

A follow-up PR will update the examples.