### PR TITLE
Add missing requestKey in example

### DIFF
--- a/docs/requests/request-keys.md
+++ b/docs/requests/request-keys.md
@@ -205,13 +205,14 @@ const searchStatus = getStatus(state, 'books.requests.search.status');
 When the request succeeds, you dispatch the following action:
 
 ```js
-import { actionTypes } fom 'redux-resource';
+import { actionTypes } from 'redux-resource';
 import store from './store';
 
 store.dispatch({
   type: actionTypes.READ_RESOURCES_SUCCEEDED,
   resourceType: 'books',
   request: 'search',
+  requestKey: 'books.requests.search.status',
   // `newResources` are the list of books that were returned by the server
   // for this query.
   resources: newResources


### PR DESCRIPTION
When the example for `getStatus` is presented, it currently lacks the `requestKey` needed as part of the READ_RESOURCES_SUCCEEDED action. If that key is missing, that entry in the `requests` section will never changed status to SUCCEEDED, instead remaining in PENDING.